### PR TITLE
Add placeholder pages for dashboard sections

### DIFF
--- a/app/dashboard/activity/page.tsx
+++ b/app/dashboard/activity/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { Title, Text } from "@mantine/core"
+
+export default function ActivityPage() {
+  return (
+    <div>
+      <Title order={2} mb="md">Activity Log</Title>
+      <Text>Recent system activities will be listed here.</Text>
+    </div>
+  )
+}

--- a/app/dashboard/bases/page.tsx
+++ b/app/dashboard/bases/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { Title, Text } from "@mantine/core"
+
+export default function BasesPage() {
+  return (
+    <div>
+      <Title order={2} mb="md">Bases</Title>
+      <Text>Overview of all bases.</Text>
+    </div>
+  )
+}

--- a/app/dashboard/soldiers/page.tsx
+++ b/app/dashboard/soldiers/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { Title, Text } from "@mantine/core"
+
+export default function SoldiersPage() {
+  return (
+    <div>
+      <Title order={2} mb="md">Soldiers</Title>
+      <Text>Manage your personnel here.</Text>
+    </div>
+  )
+}

--- a/app/dashboard/statistics/page.tsx
+++ b/app/dashboard/statistics/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { Title, Text } from "@mantine/core"
+
+export default function StatisticsPage() {
+  return (
+    <div>
+      <Title order={2} mb="md">Statistics</Title>
+      <Text>Key metrics and charts will appear here.</Text>
+    </div>
+  )
+}

--- a/app/dashboard/tactical/page.tsx
+++ b/app/dashboard/tactical/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { Title, Text } from "@mantine/core"
+
+export default function TacticalPage() {
+  return (
+    <div>
+      <Title order={2} mb="md">Tactical Map</Title>
+      <Text>The tactical map will be displayed here.</Text>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for upcoming dashboard sections so navigation links work

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6876fb45daf883298c10c8b8277abf6b